### PR TITLE
Consistent and more detailed log messages across entire codebase

### DIFF
--- a/cmd/porgs/handler.go
+++ b/cmd/porgs/handler.go
@@ -30,7 +30,7 @@ func getHandlers() *http.ServeMux {
 func getAssetHandler() http.Handler {
 	assetsDir, err := fs.Sub(embeddedFS, "assets")
 	if err != nil {
-		slog.Error("handlers: assets", "err", err)
+		slog.Error("getAssetHandler", "err", err)
 		os.Exit(1)
 	}
 	return http.StripPrefix("/a", http.FileServer(http.FS(assetsDir)))
@@ -39,7 +39,7 @@ func getAssetHandler() http.Handler {
 func getPluginAssetHandler(plugin porgs.Plugin) http.Handler {
 	assetsDir, err := fs.Sub(plugin.GetFS(), "assets")
 	if err != nil {
-		slog.Error("handlers: plugin assets", "plugin", plugin.GetName(), "err", err)
+		slog.Error("getPluginAssetHandler", "plugin", plugin.GetName(), "err", err)
 		os.Exit(1)
 	}
 	return http.StripPrefix("/a/"+plugin.GetName(), http.FileServer(http.FS(assetsDir)))

--- a/cmd/porgs/login.go
+++ b/cmd/porgs/login.go
@@ -36,7 +36,7 @@ func handleLoginPost() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// # Extract username and password from the form
 		if err := r.ParseForm(); err != nil {
-			slog.Error("login: form", "err", err)
+			slog.Error("main.handleLoginPost: parse form", "err", err)
 			porgs.ShowDefaultErrorPage(w, r)
 			return
 		}
@@ -46,7 +46,7 @@ func handleLoginPost() http.Handler {
 		// # Find the user record with this username
 		conn, err := porgs.DbConnPool.Take(r.Context())
 		if err != nil {
-			slog.Error("login: take conn", "err", err)
+			slog.Error("main.handleLoginPost: get db conn", "usr", usr, "err", err)
 			porgs.ShowDefaultErrorPage(w, r)
 			return
 		}
@@ -54,7 +54,7 @@ func handleLoginPost() http.Handler {
 
 		stSelect, err := conn.Prepare("SELECT password, salt FROM user WHERE username = ?")
 		if err != nil {
-			slog.Error("login: select stmt prepare", "err", err)
+			slog.Error("main.handleLoginPost: stmt prepare", "usr", usr, "err", err)
 			porgs.ShowDefaultErrorPage(w, r)
 			return
 		}
@@ -64,12 +64,12 @@ func handleLoginPost() http.Handler {
 
 		hasRow, err := stSelect.Step()
 		if err != nil {
-			slog.Error("login: select stmt step", "err", err)
+			slog.Error("main.handleLoginPost: stmt step", "usr", usr, "err", err)
 			porgs.ShowDefaultErrorPage(w, r)
 			return
 		}
 		if !hasRow {
-			slog.Info("login: user not found", "usr", usr)
+			slog.Info("main.handleLoginPost", "usr", usr, "msg", "not found")
 			porgs.RenderView(w, r, porgs.View{Name: "main-login", Title: "Login | PORGS", Data: vmLogin{
 				Usr: usr,
 				Msg: MsgInvalidCredentials,
@@ -82,12 +82,12 @@ func handleLoginPost() http.Handler {
 		salt := stSelect.GetText("salt")
 		match, err := pwdMatch(pwd, password, salt)
 		if err != nil {
-			slog.Error("login: pwd match", "err", err)
+			slog.Error("main.handleLoginPost: match pwd", "usr", usr, "err", err)
 			porgs.ShowDefaultErrorPage(w, r)
 			return
 		}
 		if !match {
-			slog.Info("login: incorrect pwd", "usr", usr)
+			slog.Info("main.handleLoginPost: match pwd", "usr", usr, "msg", "incorrect password")
 			porgs.RenderView(w, r, porgs.View{Name: "main-login", Title: "Login | PORGS", Data: vmLogin{
 				Usr: usr,
 				Msg: MsgInvalidCredentials,
@@ -98,7 +98,7 @@ func handleLoginPost() http.Handler {
 		// # Generate session token
 		token, err := porgs.RandomBase64String(16)
 		if err != nil {
-			slog.Error("login: generate token", "err", err)
+			slog.Error("main.handleLoginPost: generate token", "usr", usr, "err", err)
 			porgs.ShowDefaultErrorPage(w, r)
 			return
 		}
@@ -107,7 +107,7 @@ func handleLoginPost() http.Handler {
 		now := time.Now().UTC().Unix()
 		stInsert, err := conn.Prepare("INSERT INTO session (id, created, updated, username) VALUES (?, ?, ?, ?)")
 		if err != nil {
-			slog.Error("login: insert stmt prepare", "err", err)
+			slog.Error("main.handleLoginPost: save session: stmt prepare", "usr", usr, "err", err)
 			porgs.ShowDefaultErrorPage(w, r)
 			return
 		}
@@ -120,7 +120,7 @@ func handleLoginPost() http.Handler {
 
 		_, err = stInsert.Step()
 		if err != nil {
-			slog.Error("login: insert stmt exec", "err", err)
+			slog.Error("main.handleLoginPost: save session: stmt exec", "usr", usr, "err", err)
 			porgs.ShowDefaultErrorPage(w, r)
 			return
 		}
@@ -167,14 +167,14 @@ func handleLogout() http.Handler {
 		// # so she will be logged out from all devices.
 		conn, err := porgs.DbConnPool.Take(r.Context())
 		if err != nil {
-			slog.Error("logout: take conn", "err", err)
+			slog.Error("main.handleLogout: get db conn", "usr", user, "err", err)
 			porgs.ShowDefaultErrorPage(w, r)
 			return
 		}
 		defer porgs.DbConnPool.Put(conn)
 		stmt, err := conn.Prepare("DELETE FROM session WHERE username = ?")
 		if err != nil {
-			slog.Error("logout: delete stmt prepare", "err", err)
+			slog.Error("main.handleLogout: stmt prepare", "usr", user, "err", err)
 			porgs.ShowDefaultErrorPage(w, r)
 			return
 		}
@@ -182,7 +182,7 @@ func handleLogout() http.Handler {
 		stmt.BindText(1, user.Name)
 		_, err = stmt.Step()
 		if err != nil {
-			slog.Error("logout: delete stmt exec", "err", err)
+			slog.Error("main.handleLogout: stmt exec", "usr", user, "err", err)
 			porgs.ShowDefaultErrorPage(w, r)
 			return
 		}

--- a/cmd/porgs/main.go
+++ b/cmd/porgs/main.go
@@ -43,12 +43,12 @@ func main() {
 func getBootConfig() porgs.AppBootConfig {
 	host := os.Getenv("PORGS_HOST")
 	if host == "" {
-		slog.Info("getBootConfig: host", "msg", "PORGS_HOST not set or is set to \"\"")
+		slog.Info("getBootConfig: host", "default", "", "msg", "PORGS_HOST not set or is empty")
 	}
 
 	portStr := os.Getenv("PORGS_PORT")
 	if portStr == "" {
-		slog.Info("getBootConfig: port", "msg", "PORGS_PORT not set, default \"8642\"")
+		slog.Info("getBootConfig: port", "default", "8642", "msg", "PORGS_PORT not set")
 		portStr = "8642"
 	}
 	port, err := strconv.Atoi(portStr)
@@ -59,7 +59,7 @@ func getBootConfig() porgs.AppBootConfig {
 
 	dsn := os.Getenv("PORGS_DSN")
 	if dsn == "" {
-		slog.Info("getBootConfig: dsn", "msg", "PORGS_DSN not set, default \"porgs.db\"")
+		slog.Info("getBootConfig: dsn", "default", "porgs.db", "msg", "PORGS_DSN not set")
 		dsn = "porgs.db"
 	}
 

--- a/cmd/porgs/middleware.go
+++ b/cmd/porgs/middleware.go
@@ -20,7 +20,7 @@ func idUser(h http.Handler) http.Handler {
 
 		u, err := findUserBySessionToken(id.Value)
 		if err != nil {
-			slog.Error("idUser: find user", "err", err)
+			slog.Error("main.idUser: find user", "err", err)
 			u = porgs.User{Name: porgs.AnonUser}
 		}
 

--- a/cmd/porgs/templates.go
+++ b/cmd/porgs/templates.go
@@ -19,7 +19,7 @@ func getLayoutTemplate() *template.Template {
 
 	layout, err := template.New("layout").Funcs(fm).ParseFS(embeddedFS, "layouts/default.go.html")
 	if err != nil {
-		slog.Error("templates: parse layouts", "err", err)
+		slog.Error("porgs.getLayoutTemplate", "err", err)
 		os.Exit(1)
 	}
 
@@ -46,25 +46,26 @@ func parseViewTemplates(embedFS embed.FS, layout *template.Template) map[string]
 
 	viewFiles, err := fs.Glob(embedFS, "views/*.go.html")
 	if err != nil {
-		slog.Error("parse views", "err", err)
+		slog.Error("porgs.parseViewTemplates", "err", err)
 		os.Exit(1)
 	}
 	for _, viewFile := range viewFiles {
 		viewNameMatches := rgxpViewName.FindStringSubmatch(viewFile)
 		if viewNameMatches == nil {
-			slog.Error("parse view: incorrect file name", "file", viewFile)
+			slog.Error("porgs.parseViewTemplates: get view name",
+				"viewFile", viewFile, "err", "incorrect file name")
 			os.Exit(1)
 		}
 		viewName := viewNameMatches[1]
 
 		tp, err := layout.Clone()
 		if err != nil {
-			slog.Error("clone layout", "err", err)
+			slog.Error("porgs.parseViewTemplates: clone layout", "err", err)
 			os.Exit(1)
 		}
 		tp, err = tp.ParseFS(embedFS, viewFile)
 		if err != nil {
-			slog.Error("parse view", "view", viewName, "err", err)
+			slog.Error("porgs.parseViewTemplates: parse", "viewName", viewName, "err", err)
 			os.Exit(1)
 		}
 		tm[viewName] = tp

--- a/core/init.go
+++ b/core/init.go
@@ -2,11 +2,9 @@ package core
 
 import (
 	"context"
-	"log/slog"
 )
 
 func (p *Plugin) GetInit(_ context.Context) error {
 	loadData()
-	slog.Info("core: ready")
 	return nil
 }

--- a/core/load.go
+++ b/core/load.go
@@ -16,20 +16,19 @@ func loadData() {
 	if loadDir == "" {
 		return
 	}
-	slog.Info("core: load data", "PORGS_LOAD_DIR", loadDir)
+	slog.Info("core.loadData", "PORGS_LOAD_DIR", loadDir)
 
 	// Check if loadDir is valid
 	info, err := os.Stat(loadDir)
 	if err != nil {
-		slog.Error("core: loadData: check directory",
-			"PORGS_LOAD_DIR", loadDir, "error", err)
+		slog.Error("core.loadData: check directory", "err", err)
 		os.Exit(3)
 	}
 	if !info.IsDir() {
-		slog.Error("core: loadData: check directory",
-			"PORGS_LOAD_DIR", loadDir, "error", "not a directory")
+		slog.Error("core.loadData: check directory", "err", "not a directory")
 		os.Exit(3)
 	}
+	slog.Info("core.loadData: check directory: ok")
 
 	loadOrgs(loadDir)
 }
@@ -39,26 +38,30 @@ func loadOrgs(directory string) {
 	for {
 		orgs, err := readOrgCSVsForLevel(directory, level)
 		if err != nil {
-			slog.Error("loadOrgs", "err", err)
+			slog.Error("core.loadOrgs: read cvs files for 1 level", "level", level, "err", err)
 			os.Exit(3)
 		}
-
-		if len(orgs) == 0 {
-			return
-		}
+		slog.Info("core.loadOrgs: read cvs files for 1 level: ok", "level", level, "orgsCount", len(orgs))
 
 		if level == 0 && len(orgs) != 1 {
-			slog.Error("loadOrgs", "err", "there can only be one level 0 (root) organization")
+			slog.Error("core.loadOrgs: check root org", "err", "there can only be one level 0 (root) organization")
 			os.Exit(3)
+		}
+		slog.Info("core.loadOrgs: check root org: ok")
+
+		if len(orgs) == 0 {
+			slog.Info("core.loadOrgs: ok", "highestLevel", level-1)
+			return
 		}
 
 		for _, org := range orgs {
 			err = SaveOrg(org)
 			if err != nil {
-				slog.Error("loadOrgs", "err", err)
+				slog.Error("core.loadOrgs: save org", "level", level, "org", org, "err", err)
 				os.Exit(3)
 			}
 		}
+		slog.Error("core.loadOrgs: save: ok", "level", level, "orgsCount", len(orgs))
 
 		level++
 	}
@@ -86,6 +89,8 @@ func readOrgCSVsForLevel(directory string, level int) ([]Org, error) {
 }
 
 func readOrgCSV(filePath string) ([]Org, error) {
+	fileName := filepath.Base(filePath)
+
 	// # Open the file
 	file, err := os.Open(filePath)
 	if err != nil {
@@ -97,32 +102,33 @@ func readOrgCSV(filePath string) ([]Org, error) {
 	reader := csv.NewReader(file)
 	header, err := reader.Read()
 	if err != nil {
-		return nil, fmt.Errorf("read header: %w", err)
+		return nil, fmt.Errorf("core.readOrgCSV %s: header: %w", fileName, err)
 	}
 	numFields := len(header)
 	if numFields < 6 {
-		return nil, fmt.Errorf("at least 6 columns expected, got: %d", numFields)
+		return nil, fmt.Errorf("core.readOrgCSV %s: header: column count: 6 or more expected, only got: %d",
+			fileName, numFields)
 	}
 
 	// # Validate header has the required 6 fields
 	header[0] = strings.Trim(header[0], "\uFEFF") // Remove BOM
 	if header[0] != "PID" {
-		return nil, fmt.Errorf("PID column expected as field #1, got: %s", header[0])
+		return nil, fmt.Errorf("core.readOrgCSV %s: header: coulmn 1: should be named PID, got \"%s\"", fileName, header[0])
 	}
 	if header[1] != "SID" {
-		return nil, fmt.Errorf("SID column expected as field #2, got: %s", header[1])
+		return nil, fmt.Errorf("core.readOrgCSV %s: header: coulmn 2: should be named SID, got \"%s\"", fileName, header[1])
 	}
 	if header[2] != "ID" {
-		return nil, fmt.Errorf("ID column expected as field #3, got: %s", header[2])
+		return nil, fmt.Errorf("core.readOrgCSV %s: header: coulmn 3: should be named ID, got \"%s\"", fileName, header[2])
 	}
 	if header[3] != "EID" {
-		return nil, fmt.Errorf("EID (ExternalID) column expected as field #4, got: %s", header[3])
+		return nil, fmt.Errorf("core.readOrgCSV %s: header: coulmn 4: should be named EID, got \"%s\"", fileName, header[3])
 	}
 	if header[4] != "ESID" {
-		return nil, fmt.Errorf("ESID (ExternalSID) column expected as field #5, got: %s", header[4])
+		return nil, fmt.Errorf("core.readOrgCSV %s: header: coulmn 5: should be named ESID, got \"%s\"", fileName, header[4])
 	}
 	if header[5] != "NAME" {
-		return nil, fmt.Errorf("NAME column expected as field #6, got: %s", header[5])
+		return nil, fmt.Errorf("core.readOrgCSV %s: header: coulmn 6: should be named NAME, got \"%s\"", fileName, header[5])
 	}
 
 	// # Figure out the column indexes for the various translations of the NAME property
@@ -132,24 +138,26 @@ func readOrgCSV(filePath string) ([]Org, error) {
 	for i := 6; i < numFields; i++ {
 		fld := header[i]
 		if fld == "" {
-			return nil, fmt.Errorf("header: empty field Name at column %d", i+1)
+			return nil, fmt.Errorf("core.readOrgCSV %s: header: column %d: name empty", fileName, i+1)
 		}
 
 		// TODO: Handle fields beyond NAME
 		if !strings.HasPrefix(fld, "NAME_") {
-			slog.Warn("readOrgCSV: invalid field name", "col", i+1, "field", fld)
+			slog.Warn("core.readOrgCSV: header", "fileName",
+				fileName, "column", i+1, "err", fmt.Sprintf("name unrecognized: %s", fld))
+			//core.readOrgCSV
 			continue
 		}
 
 		matches := rxName.FindStringSubmatch(fld)
-
 		if len(matches) != 2 {
-			return nil, fmt.Errorf("header: invalid field Name at column %d: %s", i+1, fld)
+			return nil, fmt.Errorf("core.readOrgCSV %s: header: column %d: name has invalid language suffix: %s",
+				fileName, i+1, fld)
 		}
 		idx := matches[1]
 		indexOfNameByLang[idx] = i
 	}
-	slog.Debug("indexOfNameByLang", "indexOfNameByLang", indexOfNameByLang)
+	slog.Info("core.readOrgCSV: header: ok", "fileName", fileName, "indexOfNameByLang", indexOfNameByLang)
 
 	// # Read the data
 	var orgs []Org
@@ -160,10 +168,12 @@ func readOrgCSV(filePath string) ([]Org, error) {
 			if err.Error() == "EOF" {
 				break
 			}
-			return nil, fmt.Errorf("read line %d: %w", line, err)
+			return nil, fmt.Errorf("core.readOrgCSV %s: data: row %d: %w", fileName, line, err)
 		}
+		// TODO: Compare with the actual number of columns found when parsing the header
 		if len(rec) < 8 {
-			return nil, fmt.Errorf("8 columns expected, got: %d", len(rec))
+			return nil, fmt.Errorf("core.readOrgCSV %s: data: row %d: column count should be 8 or more, found %d",
+				fileName, line, len(rec))
 		}
 
 		org := Org{}
@@ -171,7 +181,8 @@ func readOrgCSV(filePath string) ([]Org, error) {
 		if pidVal != "" {
 			pid, err := strconv.Atoi(pidVal)
 			if err != nil {
-				return nil, fmt.Errorf("line %d: invalid PID: %w", line, err)
+				return nil, fmt.Errorf("core.readOrgCSV %s: data: row %d: column %d: field PID: %w",
+					fileName, line, 1, err)
 			}
 			org.ParentID = int64(pid)
 		}
@@ -179,14 +190,16 @@ func readOrgCSV(filePath string) ([]Org, error) {
 		sidVal := rec[1]
 		sid, err := strconv.Atoi(sidVal)
 		if err != nil {
-			return nil, fmt.Errorf("line %d: invalid SID: %w", line, err)
+			return nil, fmt.Errorf("core.readOrgCSV %s: data: row %d: column %d: field SID: %w",
+				fileName, line, 2, err)
 		}
 		org.SequenceID = int64(sid)
 
 		idVal := rec[2]
 		id, err := strconv.Atoi(idVal)
 		if err != nil {
-			return nil, fmt.Errorf("line %d: invalid OID: %w", line, err)
+			return nil, fmt.Errorf("core.readOrgCSV %s: data: row %d: column %d: field ID: %w",
+				fileName, line, 3, err)
 		}
 		org.ID = int64(id)
 
@@ -195,7 +208,8 @@ func readOrgCSV(filePath string) ([]Org, error) {
 
 		org.Name = rec[5]
 		if rec[5] == "" {
-			return nil, fmt.Errorf("name is required. line: %d, file: %s", line, filePath)
+			return nil, fmt.Errorf("core.readOrgCSV %s: data: row %d: column %d: field NAME: is empty",
+				fileName, line, 6)
 		}
 
 		trlx := make(map[string]OrgProps)
@@ -208,5 +222,6 @@ func readOrgCSV(filePath string) ([]Org, error) {
 		line++
 	}
 
+	slog.Info("core.readOrgCSV: data: ok", "fileName", fileName, "count", len(orgs))
 	return orgs, nil
 }

--- a/core/load.go
+++ b/core/load.go
@@ -43,11 +43,14 @@ func loadOrgs(directory string) {
 		}
 		slog.Info("core.loadOrgs: read cvs files for 1 level: ok", "level", level, "orgsCount", len(orgs))
 
-		if level == 0 && len(orgs) != 1 {
-			slog.Error("core.loadOrgs: check root org", "err", "there can only be one level 0 (root) organization")
-			os.Exit(3)
+		if level == 0 {
+			if len(orgs) != 1 {
+				slog.Error("core.loadOrgs: check root org", "err", "there can only be one level 0 (root) organization")
+				os.Exit(3)
+			} else {
+				slog.Info("core.loadOrgs: check root org: ok")
+			}
 		}
-		slog.Info("core.loadOrgs: check root org: ok")
 
 		if len(orgs) == 0 {
 			slog.Info("core.loadOrgs: ok", "highestLevel", level-1)
@@ -61,7 +64,7 @@ func loadOrgs(directory string) {
 				os.Exit(3)
 			}
 		}
-		slog.Error("core.loadOrgs: save: ok", "level", level, "orgsCount", len(orgs))
+		slog.Info("core.loadOrgs: save: ok", "level", level, "orgsCount", len(orgs))
 
 		level++
 	}

--- a/core/orgs.go
+++ b/core/orgs.go
@@ -33,7 +33,7 @@ func handleOrg(ctx context.Context) http.Handler {
 		idStr := r.PathValue("id")
 		id, err := strconv.Atoi(idStr)
 		if err != nil {
-			slog.Error("handleOrg: can't parse ID", "id", idStr, "err", err)
+			slog.Error("core.handleOrg: parse id", "id", idStr, "err", err)
 			porgs.ShowDefaultErrorPage(w, r)
 			return
 		}
@@ -73,11 +73,11 @@ func GetSubOrgs(ctx context.Context, id int64) ([]Org, error) {
 	defer func() {
 		err = stmt.Reset()
 		if err != nil {
-			slog.Error("GetSubOrgs: stmt reset", "err", err)
+			slog.Error("core.GetSubOrgs: stmt reset", "err", err)
 		}
 		err = stmt.ClearBindings()
 		if err != nil {
-			slog.Error("GetSubOrgs: stmt clear bindings", "err", err)
+			slog.Error("core.GetSubOrgs: stmt clear", "err", err)
 		}
 	}()
 
@@ -109,7 +109,7 @@ func GetSubOrgs(ctx context.Context, id int64) ([]Org, error) {
 		trlxJSON := stmt.GetText("trlx")
 		err = json.Unmarshal([]byte(trlxJSON), &org.Trlx)
 		if err != nil {
-			slog.Error("GetSubOrgs: unmarshal Trlx", "err", err, "trlx", trlxJSON)
+			slog.Error("core.GetSubOrgs: unmarshal trlx", "trlx", trlxJSON, "err", err)
 			return nil, err
 		}
 
@@ -136,11 +136,11 @@ func GetOrg(ctx context.Context, id int64) (Org, error) {
 	defer func() {
 		err = stmt.Reset()
 		if err != nil {
-			slog.Error("GetOrg: stmt reset", "err", err)
+			slog.Error("core.GetOrg: stmt reset", "err", err)
 		}
 		err = stmt.ClearBindings()
 		if err != nil {
-			slog.Error("GetOrg: stmt clear bindings", "err", err)
+			slog.Error("core.GetOrg: stmt clear", "err", err)
 		}
 	}()
 
@@ -170,7 +170,7 @@ func GetOrg(ctx context.Context, id int64) (Org, error) {
 	trlxJSON := stmt.GetText("trlx")
 	err = json.Unmarshal([]byte(trlxJSON), &org.Trlx)
 	if err != nil {
-		slog.Error("GetOrg: unmarshal Trlx", "err", err, "trlx", trlxJSON)
+		slog.Error("core.GetOrg: unmarshal trlx", "trlx", trlxJSON, "err", err)
 		return Org{}, err
 	}
 
@@ -205,11 +205,11 @@ func SaveOrg(org Org) error {
 	defer func() {
 		err = stmt.Reset()
 		if err != nil {
-			slog.Error("SaveOrg: stmt reset", "err", err)
+			slog.Error("core.SaveOrg: stmt reset", "err", err)
 		}
 		err = stmt.ClearBindings()
 		if err != nil {
-			slog.Error("SaveOrg: stmt clear bindings", "err", err)
+			slog.Error("core.SaveOrg: stmt clear", "err", err)
 		}
 	}()
 
@@ -226,7 +226,7 @@ func SaveOrg(org Org) error {
 
 	trlxJSON, err := json.Marshal(org.Trlx)
 	if err != nil {
-		slog.Error("SaveOrg: marshal Trlx", "err", err, "Trlx", org.Trlx)
+		slog.Error("core.SaveOrg: marshal trlx", "trlx", org.Trlx, "err", err)
 		return err
 	}
 	stmt.BindText(10, string(trlxJSON))

--- a/task/init.go
+++ b/task/init.go
@@ -2,10 +2,8 @@ package task
 
 import (
 	"context"
-	"log/slog"
 )
 
 func (p *Plugin) GetInit(_ context.Context) error {
-	slog.Info("task: loaded")
 	return nil
 }

--- a/view.go
+++ b/view.go
@@ -23,7 +23,7 @@ type View struct {
 func RenderView(w http.ResponseWriter, r *http.Request, view View) {
 	t, ok := Templates[view.Name]
 	if !ok {
-		slog.Error("render", "view", view, "err", "template not found")
+		slog.Error("porgs.RenderView", "view", view, "err", "template not found")
 		http.Error(w, "", http.StatusInternalServerError)
 		return
 	}
@@ -32,7 +32,7 @@ func RenderView(w http.ResponseWriter, r *http.Request, view View) {
 
 	err := t.ExecuteTemplate(w, view.Name, view)
 	if err != nil {
-		slog.Error("render", "view", view, "err", err)
+		slog.Error("porgs.RenderView", "view", view, "err", err)
 		http.Error(w, "", http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
### Log message layout

Using slog package, a log line has the layout:
```
TIMESTAMP LOG_LEVEL LOG_MSG log_prop1_key=val1 log_prop2_key=val2 ...
```

`LOG_MSG` has the layout
```
PKG_NAME.FUNC_NAME: step: sub-step: ...
```

Examples:
- `main.initDB: connect`
- `main.initDB: check for empty db`

### Success

On success, the message gets an `: ok` appended. e.g.
- `main.initDB: connect: ok`

### Error

On error, the error message is given under the log property `err`. This is always the last one. e.g.
- `main.initDB: check for empty db: prepare prop2=42B err="some error msg"`

If a function returns an error, we do not log that error from within the same function. However, the returned error string uses the same standard format. e.g.

```go
return nil, fmt.Errorf("core.readOrgCSV %s: data: row %d: column %d: field ID: %w",
    fileName, line, col, err)
```

### Log properties

Use consistent property names:
- `reqID` - Request ID
- `usrID` - User ID
- `err` - Error message. If present, this is the last proeprty
- `msg` - General message. If present this is either the last log property or the one before the `err` property.

