### PR TITLE
Switch app language between English, Sinhala, and Tamil

### DIFF
--- a/cmd/porgs/handler.go
+++ b/cmd/porgs/handler.go
@@ -11,17 +11,18 @@ import (
 func getHandlers() *http.ServeMux {
 	mux := http.NewServeMux()
 
-	mux.Handle("/a/", getAssetHandler())
-	mux.Handle("GET /{$}", idUser(handleRoot()))
-	mux.Handle("GET /login", idUser(handleLoginGet()))
-	mux.Handle("POST /login", idUser(handleLoginPost()))
-	mux.Handle("GET /logout", idUser(rejectAnon(handleLogout())))
-	mux.Handle("GET /home", idUser(rejectAnon(handleHome())))
+	mux.Handle("/a/", idLang(getAssetHandler()))
+	mux.Handle("GET /{$}", idLang(idUser(handleRoot())))
+	mux.Handle("GET /lang/{id}", idUser(handleLang()))
+	mux.Handle("GET /login", idLang(idUser(handleLoginGet())))
+	mux.Handle("POST /login", idLang(idUser(handleLoginPost())))
+	mux.Handle("GET /logout", idLang(idUser(rejectAnon(handleLogout()))))
+	mux.Handle("GET /home", idLang(idUser(rejectAnon(handleHome()))))
 
 	for name, plugin := range porgs.Plugins {
 		mux.Handle("/a/"+name+"/", getPluginAssetHandler(plugin))
-		mux.Handle("/"+name+"/", idUser(rejectAnon(
-			http.StripPrefix("/"+name, plugin.GetHandler(porgs.Context)))))
+		mux.Handle("/"+name+"/", idLang(idUser(rejectAnon(
+			http.StripPrefix("/"+name, plugin.GetHandler())))))
 	}
 
 	return mux

--- a/cmd/porgs/lang.go
+++ b/cmd/porgs/lang.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"github.com/praja-dev/porgs"
+	"log/slog"
+	"net/http"
+)
+
+func handleLang() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		langID := r.PathValue("id")
+		slog.Info("core.handleLang", "lang", langID)
+
+		// # Check if the language is supported
+		if !porgs.IsLangSupported(langID) {
+			porgs.ShowErrorPage(w, r, porgs.ErrorPage{
+				Msg:     fmt.Sprintf("Language not supported: %q", langID),
+				BackURL: "/",
+				Title:   "Unsupported Language",
+			})
+			return
+		}
+
+		// # Save language selection in an HttpOnly cookie
+		cookie := http.Cookie{
+			Name:     porgs.CookieNameLang,
+			Path:     "/",
+			Value:    langID,
+			MaxAge:   0,
+			HttpOnly: true,
+		}
+		http.SetCookie(w, &cookie)
+
+		// # Redirect to the same page that the request came from
+		http.Redirect(w, r, r.Header.Get("Referer"), http.StatusFound)
+	})
+}

--- a/cmd/porgs/layouts/default.go.html
+++ b/cmd/porgs/layouts/default.go.html
@@ -27,14 +27,14 @@
         </div>
     </nav>
 </header>
-{{ template "screen" .Data }}
+{{ template "screen" . }}
 <footer>
     <nav>
         <div></div>
         <div>
-            <a href="?lang=en">English</a>&nbsp;⋄
-            <a href="?lang=si">Sinhala</a>&nbsp;⋄
-            <a href="?lang=ta">Tamil</a>
+            <a href="/lang/en">English</a>&nbsp;⋄
+            <a href="/lang/si">Sinhala</a>&nbsp;⋄
+            <a href="/lang/ta">Tamil</a>
         </div>
         <div></div>
     </nav>

--- a/cmd/porgs/layouts/default.go.html
+++ b/cmd/porgs/layouts/default.go.html
@@ -31,7 +31,11 @@
 <footer>
     <nav>
         <div></div>
-        <div>Powered by PORGS</div>
+        <div>
+            <a href="?lang=en">English</a>&nbsp;⋄
+            <a href="?lang=si">Sinhala</a>&nbsp;⋄
+            <a href="?lang=ta">Tamil</a>
+        </div>
         <div></div>
     </nav>
 </footer>

--- a/cmd/porgs/login.go
+++ b/cmd/porgs/login.go
@@ -127,7 +127,7 @@ func handleLoginPost() http.Handler {
 
 		// # Set the session token in an HttpOnly cookie
 		cookie := http.Cookie{
-			Name:     porgs.SessionCookieName,
+			Name:     porgs.CookieNameSession,
 			Path:     "/",
 			Value:    token,
 			MaxAge:   int(24 * time.Hour),
@@ -189,7 +189,7 @@ func handleLogout() http.Handler {
 
 		// # Delete cookie
 		cookie := http.Cookie{
-			Name:     porgs.SessionCookieName,
+			Name:     porgs.CookieNameSession,
 			Path:     "/",
 			Value:    "",
 			MaxAge:   -1,

--- a/cmd/porgs/main.go
+++ b/cmd/porgs/main.go
@@ -85,8 +85,10 @@ func getDbConnPool() *sqlitex.Pool {
 
 func getSiteConfig() porgs.AppSiteConfig {
 	return porgs.AppSiteConfig{
-		Title:       "Ourville",
-		Description: "A website powered by Praja Organizations (PORGS)",
+		Title:         "Ourville",
+		Description:   "A website powered by Praja Organizations (PORGS)",
+		LangSupported: []string{"en", "si", "ta"},
+		LangDefault:   "en",
 	}
 
 }

--- a/cmd/porgs/middleware.go
+++ b/cmd/porgs/middleware.go
@@ -7,11 +7,33 @@ import (
 	"net/http"
 )
 
+// idLang middleware check for the lang cookie and set lang in request context.
+// If no lang cookie is present, lang is set to the default language
+func idLang(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id, err := r.Cookie(porgs.CookieNameLang)
+		if err != nil {
+			ctx := context.WithValue(r.Context(), "lang", porgs.SiteConfig.LangDefault)
+			h.ServeHTTP(w, r.WithContext(ctx))
+			return
+		}
+
+		var lang string
+		if !porgs.IsLangSupported(id.Value) {
+			lang = porgs.SiteConfig.LangDefault
+		} else {
+			lang = id.Value
+		}
+		ctx := context.WithValue(r.Context(), "lang", lang)
+		h.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
 // idUser middleware check for the session cookie and set user in request context.
 // If no session cookie is present, a user with name "anon" is set in the context.
 func idUser(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		id, err := r.Cookie(porgs.SessionCookieName)
+		id, err := r.Cookie(porgs.CookieNameSession)
 		if err != nil {
 			ctx := context.WithValue(r.Context(), "user", porgs.User{Name: porgs.AnonUser})
 			h.ServeHTTP(w, r.WithContext(ctx))

--- a/cmd/porgs/views/main-home.go.html
+++ b/cmd/porgs/views/main-home.go.html
@@ -10,7 +10,7 @@
 {{ define "screen" }}
     <main>
         <div class="dashboard">
-        {{- range $name, $plugin := .Plugins }}
+        {{- range $name, $plugin := .Data.Plugins }}
             <div>
                 <h3><a href="/{{$name}}">{{$name}}</a></h3>
                 <ul>

--- a/cmd/porgs/views/main-login.go.html
+++ b/cmd/porgs/views/main-login.go.html
@@ -14,7 +14,7 @@
                 <legend>Login</legend>
                 <div class="field">
                     <label for="username">Username:</label>
-                    <input type="text" id="username" name="username" value="{{.Usr}}" required aria-required="true">
+                    <input type="text" id="username" name="username" value="{{ .Data.Usr }}" required aria-required="true">
                 </div>
                 <div class="field">
                     <label for="password">Password:</label>
@@ -24,7 +24,7 @@
                     <button type="submit" class="primary">Login</button>
                 </div>
                 <p>
-                    {{.Msg}}
+                    {{ .Data.Msg }}
                 </p>
             </fieldset>
         </form>

--- a/core/handler.go
+++ b/core/handler.go
@@ -1,22 +1,21 @@
 package core
 
 import (
-	"context"
 	"github.com/praja-dev/porgs"
 	"net/http"
 )
 
-func (p *Plugin) GetHandler(ctx context.Context) *http.ServeMux {
+func (p *Plugin) GetHandler() *http.ServeMux {
 	mux := http.NewServeMux()
 
-	mux.Handle("GET /{$}", handleRoot(ctx))
-	mux.Handle("GET /orgs", handleOrgs(ctx))
-	mux.Handle("GET /org/{id}", handleOrg(ctx))
+	mux.Handle("GET /{$}", handleRoot())
+	mux.Handle("GET /orgs", handleOrgs())
+	mux.Handle("GET /org/{id}", handleOrg())
 
 	return mux
 }
 
-func handleRoot(_ context.Context) http.Handler {
+func handleRoot() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		porgs.RenderView(w, r, porgs.View{Name: "core-root", Title: "Core"})
 	})

--- a/core/load.go
+++ b/core/load.go
@@ -217,8 +217,9 @@ func readOrgCSV(filePath string) ([]Org, error) {
 
 		trlx := make(map[string]OrgProps)
 		for k, v := range indexOfNameByLang {
-			trlx[k] = OrgProps{Name: rec[v]}
+			trlx[strings.ToLower(k)] = OrgProps{Name: rec[v]}
 		}
+		trlx["en"] = OrgProps{Name: org.Name}
 		org.Trlx = trlx
 
 		orgs = append(orgs, org)

--- a/core/orgs.go
+++ b/core/orgs.go
@@ -12,9 +12,9 @@ import (
 	"time"
 )
 
-func handleOrgs(ctx context.Context) http.Handler {
+func handleOrgs() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		org, err := GetOrg(ctx, 1)
+		org, err := GetOrg(r.Context(), 1)
 		if err != nil {
 			porgs.ShowErrorPage(w, r, porgs.ErrorPage{
 				Msg:     "There are no defined organizations. Please add one.",
@@ -28,7 +28,7 @@ func handleOrgs(ctx context.Context) http.Handler {
 	})
 }
 
-func handleOrg(ctx context.Context) http.Handler {
+func handleOrg() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		idStr := r.PathValue("id")
 		id, err := strconv.Atoi(idStr)
@@ -38,7 +38,7 @@ func handleOrg(ctx context.Context) http.Handler {
 			return
 		}
 
-		org, err := GetOrg(ctx, int64(id))
+		org, err := GetOrg(r.Context(), int64(id))
 		if err != nil {
 			if errors.Is(err, porgs.ErrNotFound) {
 				porgs.ShowErrorPage(w, r, porgs.ErrorPage{

--- a/core/views/core-org.go.html
+++ b/core/views/core-org.go.html
@@ -10,23 +10,27 @@
 
 {{ define "screen" }}
 <main>
-    <h3>{{ .Name }}</h3>
-    {{ if not .SubOrgs }}
+    {{ $LANG := .Lang }}
+    {{ $D := .Data }}
+    {{ $OP := (index $D.Trlx $LANG)}}
+    <h3>{{ $OP.Name }}</h3>
+    {{ if not $D.SubOrgs }}
         <div>
             <p>No sub-organizations.</p>
         </div>
     {{ end }}
     <div>
-        {{ range .SubOrgs }}
+        {{ range $D.SubOrgs }}
+            {{ $SOP := (index .Trlx $LANG)}}
             <p>
-                <a href="/core/org/{{ .ID }}">{{ .Name }}</a>
+                <a href="/core/org/{{ .ID }}">{{ $SOP.Name }}</a>
             </p>
         {{ end }}
     </div>
     <hr />
     <p>
-        {{ if gt .ParentID 0 }}
-            <a href="/core/org/{{ .ParentID }}">Back</a>
+        {{ if gt $D.ParentID 0 }}
+            <a href="/core/org/{{ $D.ParentID }}">Back</a>
         {{ else }}
             <a href="/home">Back</a>
         {{ end }}

--- a/lang.go
+++ b/lang.go
@@ -1,0 +1,10 @@
+package porgs
+
+func IsLangSupported(langID string) bool {
+	for _, lang := range SiteConfig.LangSupported {
+		if lang == langID {
+			return true
+		}
+	}
+	return false
+}

--- a/porgs.go
+++ b/porgs.go
@@ -20,8 +20,10 @@ type AppBootConfig struct {
 
 // AppSiteConfig struct holds the website configuration.
 type AppSiteConfig struct {
-	Title       string
-	Description string
+	Title         string
+	Description   string
+	LangSupported []string
+	LangDefault   string
 }
 
 // Plugin interface for PORGS plugin integration.
@@ -42,7 +44,7 @@ type Plugin interface {
 	GetFS() embed.FS
 
 	// GetHandler returns the plugin's HTTP router.
-	GetHandler(ctx context.Context) *http.ServeMux
+	GetHandler() *http.ServeMux
 
 	// GetInit initializes the plugin.
 	GetInit(ctx context.Context) error

--- a/task/handler.go
+++ b/task/handler.go
@@ -1,20 +1,19 @@
 package task
 
 import (
-	"context"
 	"github.com/praja-dev/porgs"
 	"net/http"
 )
 
-func (p *Plugin) GetHandler(ctx context.Context) *http.ServeMux {
+func (p *Plugin) GetHandler() *http.ServeMux {
 	mux := http.NewServeMux()
 
-	mux.Handle("GET /{$}", handleRoot(ctx))
+	mux.Handle("GET /{$}", handleRoot())
 
 	return mux
 }
 
-func handleRoot(_ context.Context) http.Handler {
+func handleRoot() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		porgs.RenderView(w, r, porgs.View{Name: "task-root", Title: "Our Responsibilities"})
 	})

--- a/var.go
+++ b/var.go
@@ -36,4 +36,5 @@ var ErrNotImplemented = errors.New("not implemented")
 var ErrNotFound = errors.New("not found")
 
 const AnonUser = "anon"
-const SessionCookieName = "session"
+const CookieNameSession = "session"
+const CookieNameLang = "lang"

--- a/view.go
+++ b/view.go
@@ -12,6 +12,9 @@ type View struct {
 	// Title is the display name of the view
 	Title string
 
+	// Lang is the language to render the view in
+	Lang string
+
 	// User is the user to render the view for
 	User User
 
@@ -28,8 +31,19 @@ func RenderView(w http.ResponseWriter, r *http.Request, view View) {
 		return
 	}
 
-	view.User = r.Context().Value("user").(User)
+	lang, ok := r.Context().Value("lang").(string)
+	if !ok {
+		lang = SiteConfig.LangDefault
+	}
+	view.Lang = lang
 
+	user, ok := r.Context().Value("user").(User)
+	if !ok {
+		user = User{Name: AnonUser}
+	}
+	view.User = user
+
+	slog.Info("porgs.RenderView", "view", view.Name, "lang", lang, "user", user.Name)
 	err := t.ExecuteTemplate(w, view.Name, view)
 	if err != nil {
 		slog.Error("porgs.RenderView", "view", view, "err", err)


### PR DESCRIPTION
### Functionality Change

Foundation for localizing PORGS.

New route `GET /lang/{id}` to switch app language.
If the supplied language is supported, an HTTP only `lang` cookie is 
created and the request is redirected to the referring page.

Added links in the footer for switching languages between English, Sinhala, and Tamil.

The organization name is now displayed in the selected language on the following routes:
- `GET /core/orgs`
- `GET /core/org/{id}`

### Code Change

Added new middleware `idLang()` to detect the `lang` cookie and add the `lang` element to the request context.

Updated `porgs.RenderView()` to set Lang field on View. Updated the default layout to pass the full View object to screen template and updated the existing views to match.

Added `porgs.IsLangSupported()`

Added new fields to `AppSiteConfig`: `LangSupported` and `LangDefault`

Added new field: `View.Lang`

Added `porgs.CookieNameLang`

### Fixes

- In `porgs.RenderView()` used `anon` when session does not have a `user` element
- When passing a context argument to `GetOrg()` used `r.Context()`
- Unnecessary usage of a `ctx` argument in `Plugin.GetHandler`
- Used lowercase map keys in the Org.Trlx map
- Added translations for the default language to the Trlx map


### Refactorings

- Renamed `SessionCookieName` to `CookieNameSession`