### PR TITLE
Add --load argument for data loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,22 @@ within community and government organizations.
 
 [Setup](https://go.dev/doc/install) a Go development environment.
 
-Clone the source code repository:
+On UNIX inspired systems:
 ```shell
+cd ~/src
 git clone https://github.com/praja-dev/porgs.git
+git clone https://github.com/praja-dev/lk-data.git
+cd ~/src/porgs
+go run ./cmd/porgs --load=~/lk-data/admin
 ```
 
-Run the web app:
+On Windows:
 ```shell
-cd porgs
-go run ./cmd/porgs
+cd %USERPROFILE%\src
+git clone https://github.com/praja-dev/porgs.git
+git clone https://github.com/praja-dev/lk-data.git
+cd %USERPROFILE%\src\porgs
+go run .\cmd\porgs --load=%USERPROFILE%\lk-data\admin
 ```
 
 Open http://localhost:8642 on a web browser.
@@ -34,10 +41,25 @@ The home page (`/home`) lists the links to access functionality contributed by t
 
 Enter `Ctrl+C` to stop the porgs web app.
 
-Run the web app again—this time loading example data from `./examples/lk/data` directory.
+When starting again, don't use the `--load` argument.
 ```shell
-PORGS_LOAD_DIR=./examples/lk/data go run ./cmd/porgs
+go run ./cmd/porgs
 ```
+
+The database is created in the same directory and has the name `porgs.db`.
+This can be changed using the `PORGS_DSN` environment variable.
+
+The database consists of three files:
+- `porgs.db` - the main SQLite database file containing all tables, indexes etc.
+- `porgs.db-wal` - write-ahead log file needed for WAL mode
+- `porgs.db-shm` - shared memory file needed for WAL mode
+
+You can safely delete these files to start fresh.
+
+The [praja-dev/lk-data](https://github.com/praja-dev/lk-data.git) project is for creating a base dataset
+for Sri Lanka starting from the country level (level 0 admin unit) down to the village level (level 4 admin unit).
+
+For a truncated version of the lk-data dataset, refer to the [examples/lk/data directory](examples/lk/data) in the porgs project.  
 
 ## Design
 

--- a/cmd/porgs/main.go
+++ b/cmd/porgs/main.go
@@ -168,7 +168,7 @@ func initDB() {
 
 func initPlugins() {
 	for _, plugin := range porgs.Plugins {
-		err := plugin.GetInit(porgs.Context)
+		err := plugin.GetInit()
 		if err != nil {
 			slog.Error("initPlugins", "plugin", plugin.GetName(), "err", err)
 			os.Exit(2)

--- a/core/init.go
+++ b/core/init.go
@@ -1,10 +1,6 @@
 package core
 
-import (
-	"context"
-)
-
-func (p *Plugin) GetInit(_ context.Context) error {
+func (p *Plugin) GetInit() error {
 	loadData()
 	return nil
 }

--- a/core/load.go
+++ b/core/load.go
@@ -3,6 +3,7 @@ package core
 import (
 	"encoding/csv"
 	"fmt"
+	"github.com/praja-dev/porgs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -12,11 +13,16 @@ import (
 )
 
 func loadData() {
-	loadDir := os.Getenv("PORGS_LOAD_DIR")
-	if loadDir == "" {
+	loadDir, ok := porgs.Args["--load"]
+	if !ok {
 		return
 	}
-	slog.Info("core.loadData", "PORGS_LOAD_DIR", loadDir)
+	if loadDir == "" {
+		slog.Error("core.loadData", "err",
+			"--load arg value should be the source directory path - e.g. --load=~/src/lk-data/admin")
+		os.Exit(3)
+	}
+	slog.Info("core.loadData", "path", loadDir)
 
 	// Check if loadDir is valid
 	info, err := os.Stat(loadDir)

--- a/porgs.go
+++ b/porgs.go
@@ -1,7 +1,6 @@
 package porgs
 
 import (
-	"context"
 	"embed"
 	"net/http"
 )
@@ -47,5 +46,5 @@ type Plugin interface {
 	GetHandler() *http.ServeMux
 
 	// GetInit initializes the plugin.
-	GetInit(ctx context.Context) error
+	GetInit() error
 }

--- a/task/init.go
+++ b/task/init.go
@@ -1,9 +1,5 @@
 package task
 
-import (
-	"context"
-)
-
-func (p *Plugin) GetInit(_ context.Context) error {
+func (p *Plugin) GetInit() error {
 	return nil
 }

--- a/var.go
+++ b/var.go
@@ -8,6 +8,9 @@ import (
 	"zombiezen.com/go/sqlite/sqlitex"
 )
 
+// Args holds command-line arguments.
+var Args map[string]string
+
 // Context is the root context for the system.
 var Context context.Context
 


### PR DESCRIPTION
- Implement `main.parseArgs()` to parse command-line arguments into a map and
  store them in `porgs.Args`.
- Update README with clear setup instructions for both UNIX and Windows.
